### PR TITLE
misc: Remove AVX checks and enable Windows builds pipeline

### DIFF
--- a/.github/workflows/Windows_build.yml
+++ b/.github/workflows/Windows_build.yml
@@ -90,7 +90,7 @@ jobs:
           if-no-files-found: error
       - name: Create release
         if: |
-          github.repository == 'xenia-canary/xenia-canary' &&
+          github.repository == 'mavethee/xenia-canary-no-avx-check' &&
           github.event.action != 'pull_request' &&
           github.ref == 'refs/heads/canary_experimental' &&
           matrix.vsver == '2019'

--- a/src/xenia/base/main_init_win.cc
+++ b/src/xenia/base/main_init_win.cc
@@ -21,9 +21,10 @@ class StartupCpuFeatureCheck {
     const char* error_message = nullptr;
     if (!cpu.has(Xbyak::util::Cpu::tAVX)) {
       error_message =
-          "Your CPU does not support AVX, which is required by Xenia. See "
-          "the "
-          "FAQ for system requirements at https://xenia.jp";
+          "Your CPU does not advertise AVX support, which is required by "
+          "Xenia. "
+          "If running on Apple Silicon Mac on macOS 15 and later, this is "
+          "thanks to Apple that can't implement things right.";
     }
     if (error_message == nullptr) {
       return;
@@ -31,7 +32,7 @@ class StartupCpuFeatureCheck {
       // TODO(gibbed): detect app type and printf instead, if needed?
       MessageBoxA(nullptr, error_message, "Xenia Error",
                   MB_OK | MB_ICONERROR | MB_SETFOREGROUND);
-      ExitProcess(static_cast<uint32_t>(-1));
+      // ExitProcess(static_cast<uint32_t>(-1));
     }
   }
 };

--- a/src/xenia/cpu/backend/x64/x64_backend.cc
+++ b/src/xenia/cpu/backend/x64/x64_backend.cc
@@ -225,8 +225,11 @@ bool X64Backend::Initialize(Processor* processor) {
 
   Xbyak::util::Cpu cpu;
   if (!cpu.has(Xbyak::util::Cpu::tAVX)) {
-    XELOGE("This CPU does not support AVX. The emulator will now crash.");
-    return false;
+    // XELOGE("This CPU does not support AVX. The emulator will now crash.");
+    XELOGE(
+        "This CPU does not advertise AVX support. The emulator will crash if "
+        "AVX is missing");
+    // return false;
   }
 
   // Need movbe to do advanced LOAD/STORE tricks.

--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -92,12 +92,12 @@ X64Emitter::X64Emitter(X64Backend* backend, XbyakAllocator* allocator)
       backend_(backend),
       code_cache_(backend->code_cache()),
       allocator_(allocator) {
-  if (!cpu_.has(Xbyak::util::Cpu::tAVX)) {
-    xe::FatalError(
-        "Your CPU does not support AVX, which is required by Xenia. See the "
-        "FAQ for system requirements at https://xenia.jp");
-    return;
-  }
+  // if (!cpu_.has(Xbyak::util::Cpu::tAVX)) {
+  //   xe::FatalError(
+  //       "Your CPU does not support AVX, which is required by Xenia. See the "
+  //       "FAQ for system requirements at https://xenia.jp");
+  //   return;
+  // }
 
   feature_flags_ = amd64::GetFeatureFlags();
 


### PR DESCRIPTION
## Details:

Own fork for more frequent updates (aka to be up to date with main `xenia-canary` branch).

**Credits:**
https://github.com/fnschmidt/xenia-canary-noavxcheck
